### PR TITLE
Cell _top and _bottom methods fail when cell becomes too vertical

### DIFF
--- a/colicoords/cell.py
+++ b/colicoords/cell.py
@@ -1254,27 +1254,31 @@ class Coordinates(object):
     def _top(self):
         """:obj:`float`: Length of the cell's top membrane segment."""
 
-        # http://tutorial.math.lamar.edu/Classes/CalcII/ParaArcLength.aspx
-        def integrant_top(t, a1, a2, r):
-            return np.sqrt(1 + (a1 + 2 * a2 * t) ** 2 + ((4 * a2 ** 2 * r ** 2) / (1 + (a1 + 2 * a2 * t) ** 2) ** 2) + (
-                        (4 * a2 * r) / np.sqrt(1 + (a1 + 2 * a2 * t))))
+        t = np.linspace(self.xl, self.xr, num=100)
+        a0, a1, a2 = self.coeff
 
-        top, terr = quad(integrant_top, self.xl, self.xr,
-                         args=(self.a1, self.a2, self.r))
-        return top
+        x_top = t + self.r * ((a1 + 2 * a2 * t) / np.sqrt(1 + (a1 + 2 * a2 * t) ** 2))
+        y_top = a0 + a1 * t + a2 * (t ** 2) - self.r * (1 / np.sqrt(1 + (a1 + 2 * a2 * t) ** 2))
+
+        top_arr = np.asarray([y_top, x_top]).swapaxes(1, 0)
+        d = np.diff(top_arr, axis=0)
+        dists = np.sqrt((d ** 2).sum(axis=1))
+        return np.sum(dists)
 
     @property
     def _bot(self):
         """:obj:`float`: Length of the cell's bottom membrane segment."""
 
-        # http://tutorial.math.lamar.edu/Classes/CalcII/ParaArcLength.aspx\
-        def integrant_bot(t, a1, a2, r):
-            return np.sqrt(1 + (a1 + 2 * a2 * t) ** 2 + ((4 * a2 ** 2 * r ** 2) / (1 + (a1 + 2 * a2 * t) ** 2) ** 2) - (
-                        (4 * a2 * r) / np.sqrt(1 + (a1 + 2 * a2 * t))))
+        t = np.linspace(self.xl, self.xr, num=100)
+        a0, a1, a2 = self.coeff
 
-        bot, berr = quad(integrant_bot, self.xl, self.xr,
-                         args=(self.a1, self.a2, self.r))
-        return bot
+        x_bot = t + - self.r * ((a1 + 2 * a2 * t) / np.sqrt(1 + (a1 + 2 * a2 * t) ** 2))
+        y_bot = a0 + a1 * t + a2 * (t ** 2) + self.r * (1 / np.sqrt(1 + (a1 + 2 * a2 * t) ** 2))
+
+        bot_arr = np.asarray([y_bot, x_bot]).swapaxes(1, 0)
+        d = np.diff(bot_arr, axis=0)
+        dists = np.sqrt((d ** 2).sum(axis=1))
+        return np.sum(dists)
 
     def p(self, x_arr):
         """


### PR DESCRIPTION
Great work, currently using in my research!

When working with cells that are more vertical we found the calculation of the circumference (Cell.circumference) fails and returns a NaN. Looking into it, we found that's because the integrals in the Coordinates._top and _bottom methods diverge for such conditions - maybe a small bug in the analytic expression of the arc length integrand.

Attached is an example bitmap of a failing cell. To reproduce fully, initialise a cell over it with the following parameters:

{'xl': 9.052183818572, 'xr': 16.473663643227702, 'a0': 75.8840251535968, 'a1': -4.77838056145959, 'a2': 0.03780895333655627, 'r': 7.0710678118654755, 'shape': (45, 26)}

[exmaple_failing_cell.zip](https://github.com/Jhsmit/ColiCoords/files/6744516/exmaple_failing_cell.zip)


In our local version of the lib, fixed by changing the calculation to be numerical by piecewise integration. Testing reveals identical results for all cells, with the additional ability to handle vertical ones. Consider merging to fix the issue! Also opened an issue about this!

This commit fixes #119 